### PR TITLE
Handle SecureString parameters

### DIFF
--- a/azuredeploy.tests.ps1
+++ b/azuredeploy.tests.ps1
@@ -161,7 +161,8 @@ Function Test-AzureJson {
               }
 
               "securestring" {
-                $TemplateParameters.Add($Parameter, "dummystring")
+                $secureValue = (ConvertTo-SecureString "dummystring" -asplaintext -force)
+                $TemplateParameters.Add($Parameter, $secureValue)
               }
 
               "array" {


### PR DESCRIPTION
Got the following error when I tried out the script:

> Cannot convert the "dummystring" value of type "System.String" to type "System.Security.SecureString".

Fixed it by making sure that the script passes a `SecureString` to parameters of type `securestring`.