### PR TITLE
Better handling of bracket counting

### DIFF
--- a/azuredeploy.tests.ps1
+++ b/azuredeploy.tests.ps1
@@ -86,9 +86,10 @@ Function Test-AzureJson {
     }
   }
 
-  Context "Missing opening or closing square brackets" {
+  Context "Missing opening or closing square 
+  ets" {
     For($i=0;$i -lt $jsonMainTemplate.Length;$i++) {
-      $Matches = [System.Text.RegularExpressions.Regex]::Matches($jsonMainTemplate[$i],"\"".*\""")
+      $Matches = [System.Text.RegularExpressions.Regex]::Matches($jsonMainTemplate[$i],'"(?:[^"\\]|\\.)*"')
 
       ForEach($Match In $Matches) {
         $PairCharNumber = ($Match.Value.Length - $Match.Value.Replace("[","").Replace("]","").Length) % 2


### PR DESCRIPTION
This will fix  #3 

Adjusted regex for getting quoted strings. Currently it's a little too greedy. e.g.

>  "arrayprop": ["item1", "item2"]

will give you match `"arrayprop": ["item1", "item2"`, which again will give you a missmatch of bracket count.

The fix for this, is to make the regex lazy, but also ensure that it won't match escaped quotes. E.g.

>  "prop": "[concat(\\"item1\\", \\"item2\\")]"
 
should give two matches: `"prop"` and `"[concat(\"item1\", \"item2\")]"`

I have not looked into other regex's in the script. Maybe other regex's also needs to be updated.